### PR TITLE
upgrade Java 11 to 17

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
     gradlePluginPortal()
 }
 
-val jvmTargetVer = JavaLanguageVersion.of(11)
+val jvmTargetVer = JavaLanguageVersion.of(17)
 
 java {
     toolchain.languageVersion.set(jvmTargetVer)

--- a/buildSrc/src/main/kotlin/common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-convention.gradle.kts
@@ -40,7 +40,7 @@ group = "io.github.creek.service"
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 

--- a/buildSrc/src/main/kotlin/common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-convention.gradle.kts
@@ -77,7 +77,7 @@ tasks.test {
 
 spotless {
     java {
-        googleJavaFormat("1.15.0").aosp().reflowLongStrings()
+        googleJavaFormat("1.25.2").aosp().reflowLongStrings()
         indentWithSpaces()
         importOrder()
         removeUnusedImports()


### PR DESCRIPTION
Upgrades Java 11 references to Java 17.

## Files changed
- `buildSrc/build.gradle.kts`: `JavaLanguageVersion.of(11)` → `JavaLanguageVersion.of(17)`
- `buildSrc/src/main/kotlin/common-convention.gradle.kts`: `JavaLanguageVersion.of(11)` → `JavaLanguageVersion.of(17)`