### PR TITLE
fix: add missing blank line in TopologyBuilder to fix Spotless check

### DIFF
--- a/handle-occurrence-service/src/main/java/io/github/creek/service/connected/services/demo/service/kafka/streams/TopologyBuilder.java
+++ b/handle-occurrence-service/src/main/java/io/github/creek/service/connected/services/demo/service/kafka/streams/TopologyBuilder.java
@@ -69,6 +69,7 @@ public final class TopologyBuilder {
 
         return builder.build(ext.properties(DEFAULT_CLUSTER_NAME));
     }
+
     // end-snippet
 
     // begin-snippet: extract-method


### PR DESCRIPTION
## Root cause

The Build workflow was failing on the `:handle-occurrence-service:spotlessJavaCheck` task due to a missing blank line in `TopologyBuilder.java`.

Spotless detected that a blank line was required between the closing `}` of the topology-building method and the `// end-snippet` comment.

## Fix

Added the missing blank line at line 72 of `TopologyBuilder.java` to satisfy the Spotless Java formatter.