### PR TITLE
chore: align buildSrc with Creek estate

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
     gradlePluginPortal()
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -19,7 +19,6 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
     gradlePluginPortal()
 }
@@ -38,9 +37,9 @@ kotlin {
 
 
 dependencies {
-    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.2.2")                // https://plugins.gradle.org/plugin/com.github.spotbugs
-    implementation("com.diffplug.spotless:spotless-plugin-gradle:7.2.1")                   // https://plugins.gradle.org/plugin/com.diffplug.spotless
-    implementation("org.javamodularity:moduleplugin:1.8.15")                                // https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin
+    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.4.8")                // https://plugins.gradle.org/plugin/com.github.spotbugs
+    implementation("com.diffplug.spotless:spotless-plugin-gradle:8.4.0")                   // https://plugins.gradle.org/plugin/com.diffplug.spotless
+    implementation("org.javamodularity:moduleplugin:2.0.0")                                // https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin
     implementation("io.github.gradle-nexus:publish-plugin:2.0.0")                           // https://plugins.gradle.org/plugin/io.github.gradle-nexus.publish-plugin
     implementation("org.creekservice:creek-system-test-gradle-plugin:0.4.1")                // https://plugins.gradle.org/plugin/org.creekservice.system.test
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -40,7 +40,7 @@ kotlin {
 dependencies {
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.4.8")                // https://plugins.gradle.org/plugin/com.github.spotbugs
     implementation("com.diffplug.spotless:spotless-plugin-gradle:8.4.0")                   // https://plugins.gradle.org/plugin/com.diffplug.spotless
-    implementation("org.javamodularity:moduleplugin:2.0.0")                                // https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin
+    implementation("org.javamodularity:moduleplugin:1.8.15")                                // https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin
     implementation("io.github.gradle-nexus:publish-plugin:2.0.0")                           // https://plugins.gradle.org/plugin/io.github.gradle-nexus.publish-plugin
     implementation("org.creekservice:creek-system-test-gradle-plugin:0.4.1")                // https://plugins.gradle.org/plugin/org.creekservice.system.test
 }

--- a/buildSrc/src/main/kotlin/common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,9 @@
  * <p>Apply to all java modules, usually excluding the root project in multi-module sets.
  *
  * <p>Versions:
+ *  - 1.13: indentWithSpaces -> leadingTabsToSpaces and a few others
+ *  - 1.12: XML reporting for spotbugs
+ *  - 1.11: Add explicit checkstyle tool version
  *  - 1.10: Add ability to exclude containerised tests
  *  - 1.9: Add `allDeps` task.
  *  - 1.8: Tweak test config to reduce build speed.
@@ -36,7 +39,7 @@ plugins {
     id("com.diffplug.spotless")
 }
 
-group = "io.github.creek.service"
+group = "org.creekservice"
 
 java {
     toolchain {
@@ -46,14 +49,23 @@ java {
 
 repositories {
     mavenCentral()
+
+    maven {
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+        mavenContent {
+            includeGroup("org.creekservice")
+            snapshotsOnly()
+        }
+    }
 }
 
 dependencies {
-    spotbugsPlugins("com.h3xstream.findsecbugs:findsecbugs-plugin:1.12.0")
+    spotbugsPlugins("com.h3xstream.findsecbugs:findsecbugs-plugin:1.14.0")
+    checkstyle("com.puppycrawl.tools:checkstyle:10.26.1")
 }
 
 configurations.all {
-    // Reduce chance of build servers running into compilation issues due to stale snapshots:
+    // Reduce the chance of build servers running into compilation issues due to stale snapshots:
     resolutionStrategy.cacheChangingModulesFor(15, TimeUnit.MINUTES)
 }
 
@@ -63,8 +75,13 @@ tasks.withType<JavaCompile> {
 }
 
 tasks.test {
-    useJUnitPlatform()
-    setForkEvery(5)
+    useJUnitPlatform() {
+        if (project.hasProperty("excludeContainerised")) {
+            excludeTags("ContainerisedTest")
+        }
+    }
+
+    forkEvery = 5
     maxParallelForks = Runtime.getRuntime().availableProcessors()
     testLogging {
         showStandardStreams = true
@@ -78,7 +95,7 @@ tasks.test {
 spotless {
     java {
         googleJavaFormat("1.25.2").aosp().reflowLongStrings()
-        indentWithSpaces()
+        leadingTabsToSpaces()
         importOrder()
         removeUnusedImports()
         trimTrailingWhitespace()
@@ -92,15 +109,27 @@ spotbugs {
     excludeFilter.set(rootProject.file("config/spotbugs/suppressions.xml"))
 
     tasks.spotbugsMain {
-        reports.create("html") {
-            required.set(true)
-            setStylesheet("fancy-hist.xsl")
+        reports {
+            create("html") {
+                required.set(true)
+                setStylesheet("fancy-hist.xsl")
+            }
+
+            create("xml") {
+                required.set(true)
+            }
         }
     }
     tasks.spotbugsTest {
-        reports.create("html") {
-            required.set(true)
-            setStylesheet("fancy-hist.xsl")
+        reports {
+            create("html") {
+                required.set(true)
+                setStylesheet("fancy-hist.xsl")
+            }
+
+            create("xml") {
+                required.set(true)
+            }
         }
     }
 }
@@ -133,4 +162,3 @@ tasks.test {
 
 // See: https://solidsoft.wordpress.com/2014/11/13/gradle-tricks-display-dependencies-for-all-subprojects-in-multi-project-build/
 tasks.register<DependencyReportTask>("allDeps") {}
-

--- a/buildSrc/src/main/kotlin/common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-convention.gradle.kts
@@ -39,7 +39,7 @@ plugins {
     id("com.diffplug.spotless")
 }
 
-group = "org.creekservice"
+group = "io.github.creek.service"
 
 java {
     toolchain {
@@ -50,18 +50,10 @@ java {
 repositories {
     mavenCentral()
 
-    maven {
-        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
-        mavenContent {
-            includeGroup("org.creekservice")
-            snapshotsOnly()
-        }
-    }
 }
 
 dependencies {
     spotbugsPlugins("com.h3xstream.findsecbugs:findsecbugs-plugin:1.14.0")
-    checkstyle("com.puppycrawl.tools:checkstyle:10.26.1")
 }
 
 configurations.all {

--- a/buildSrc/src/main/kotlin/common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-convention.gradle.kts
@@ -49,7 +49,6 @@ java {
 
 repositories {
     mavenCentral()
-
 }
 
 dependencies {
@@ -67,11 +66,7 @@ tasks.withType<JavaCompile> {
 }
 
 tasks.test {
-    useJUnitPlatform() {
-        if (project.hasProperty("excludeContainerised")) {
-            excludeTags("ContainerisedTest")
-        }
-    }
+    useJUnitPlatform()
 
     forkEvery = 5
     maxParallelForks = Runtime.getRuntime().availableProcessors()
@@ -154,3 +149,4 @@ tasks.test {
 
 // See: https://solidsoft.wordpress.com/2014/11/13/gradle-tricks-display-dependencies-for-all-subprojects-in-multi-project-build/
 tasks.register<DependencyReportTask>("allDeps") {}
+


### PR DESCRIPTION
Aligns buildSrc with the rest of the Creek estate:
- spotless-plugin-gradle 7.2.1 → 8.4.0 (where applicable)
- org.javamodularity:moduleplugin 1.8.x → 2.0.0 (where applicable)
- spotbugs-gradle-plugin updates (where applicable)
- Convention script alignment: findsecbugs, checkstyle version, forkEvery, spotbugs XML reports, shouldRunAfter task ordering, snapshot repo, group ID