### PR TITLE
chore(deps): bump codecov/codecov-action to v7.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build
         run: ./gradlew build jacocoTestReport
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: '**/build/reports/jacoco/test/jacocoTestReport.xml'


### PR DESCRIPTION
## Summary
- Bump `codecov/codecov-action` from v6.x to v7.0.0
- This is needed to get CodeCov working again. Until this is merged, all builds can fail on the CodeCov step.

See: https://github.com/creek-service/creek-kafka/pull/918

🤖 Generated with [Claude Code](https://claude.com/claude-code)